### PR TITLE
Minor patches on filetype checking

### DIFF
--- a/main.js
+++ b/main.js
@@ -158,7 +158,7 @@ class Player {
 
 	loadData(data, filename) {
 		consoleLog("Loading file " + filename, ConsoleLogTypes.Inner);
-		var ext = filename.split('.').pop();
+		var ext = filename.split('.').pop().toLowerCase();
 		if (ext == "json") ext = "lottie";
 		if (this.tvg.load(new Int8Array(data), ext, this.canvas.width, this.canvas.height)) {
 			this.filename = filename;
@@ -321,7 +321,7 @@ function openFileBrowse() {
 }
 
 function allowedFileExtension(filename) {
-	player.filetype = filename.split('.').pop();
+	player.filetype = filename.split('.').pop().toLowerCase();
 	return (player.filetype === "tvg") || (player.filetype === "svg") || (player.filetype === "json") || (player.filetype === "png") || (player.filetype === "jpg")
 }
 

--- a/main.js
+++ b/main.js
@@ -320,9 +320,11 @@ function openFileBrowse() {
 	document.getElementById('image-file-selector').click();
 }
 
+const allowedExtensionList = ['tvg', 'svg', 'json', 'png', 'jpg'];
+
 function allowedFileExtension(filename) {
 	player.filetype = filename.split('.').pop().toLowerCase();
-	return (player.filetype === "tvg") || (player.filetype === "svg") || (player.filetype === "json") || (player.filetype === "png") || (player.filetype === "jpg")
+	return allowedExtensionList.includes(player.filetype);
 }
 
 function fileDropHighlight(event) {

--- a/main.js
+++ b/main.js
@@ -320,7 +320,7 @@ function openFileBrowse() {
 	document.getElementById('image-file-selector').click();
 }
 
-const allowedExtensionList = ['tvg', 'svg', 'json', 'png', 'jpg'];
+const allowedExtensionList = ['tvg', 'svg', 'json', 'png', 'jpg', 'jpeg'];
 
 function allowedFileExtension(filename) {
 	player.filetype = filename.split('.').pop().toLowerCase();


### PR DESCRIPTION
1. Applied `toLowerCase()` to check filetype, previously any uppercases(like Jpg, JPG, jSoN) were failed to load. However this patch will support with those cases. (Issue: #14)

2. Refactored some code for same logic because we have a lot of extensions to show up, I made it into array.

3. Added `jpeg` Since jpeg and jpg are same type.