### PR TITLE
Hide drop file(canvas) text when using loadURL

### DIFF
--- a/main.js
+++ b/main.js
@@ -243,6 +243,11 @@ function loadFile(file) {
 function loadUrl(url) {
 	const fileExtension = url.split('.').pop().toLowerCase();
 	player.load(url, fileExtension);
+
+	showImageCanvas();
+	enableZoomContainer();
+	enableProgressContainer();
+	showPage("progress");
 }
 
 function createFilesListTab() {
@@ -518,3 +523,4 @@ function refreshZoomValue() {
 	value.innerHTML = player.offsetWidth + " x " + player.offsetHeight;
 	value.classList.remove("incorrect");
 }
+


### PR DESCRIPTION
When the user use LoadURL-Add, the text related to the Drop file on the existing canvas disappears.