### PR TITLE
fix: Retain resolution when switching rendering engines

### DIFF
--- a/main.js
+++ b/main.js
@@ -25,6 +25,7 @@ var filesList;
 var filetype;
 var filename;
 var filedata;
+var size = 800;
 var renderer = 'sw';
 
 //console output
@@ -240,6 +241,7 @@ function loadData(data, fileExtension) {
   // FIXME: delay should be removed
   setTimeout(async () => {
     await player.load(data, fileExtension);
+    resize(size, size);
     showAside();
     createTabs();
     showImageCanvas();
@@ -403,7 +405,7 @@ function onConsoleBottom(event) {
 
 function onZoomSlider(event) {
 	var value = event.target.value;
-	var size = Math.floor(512 * (value / 100 + 0.25));
+	size = Math.floor(512 * (value / 100 + 0.25));
 
 	resize(size, size);
 	refreshZoomValue();


### PR DESCRIPTION


https://github.com/user-attachments/assets/e9dcd440-e115-4e52-85d0-8b85f896e7a0



Issue: #81

The current resolution setting in the viewer was not preserved when changing between rendering engines (software, WebGL, WebGPU). Now, the selected resolution remains consistent across engine switches.