### PR TITLE
viewer: detect and disable unsupported renderer backends

### DIFF
--- a/main.js
+++ b/main.js
@@ -43,9 +43,33 @@ const ConsoleLogTypes = { None : '', Inner : 'console-type-inner', Error : 'cons
 	};
 })();
 
+//renderer support check
+function isWebGLAvailable() {
+	try {
+		var canvas = document.createElement('canvas');
+		return Boolean(window.WebGLRenderingContext && (canvas.getContext('webgl') || canvas.getContext('experimental-webgl')));
+	} catch (e) {
+		return false;
+	}
+}
+
+function isWebGPUAvailable() {
+	return typeof navigator.gpu !== 'undefined';
+}
+
+function checkRendererSupport() {
+	const rendererDropdown = document.getElementById('renderer-dropdown');
+	const rendererOptions = rendererDropdown.querySelectorAll('option');
+	rendererOptions.forEach(option => {
+		const shouldDisable = (option.value === 'gl' && !isWebGLAvailable()) || (option.value === 'wg' && !isWebGPUAvailable());
+		option.disabled = shouldDisable;
+	});
+}
+
 //initialization
 window.onload = () => {
 	initialize();
+	checkRendererSupport();
 	filesList = new Array();
 	loadFromWindowURL();
 


### PR DESCRIPTION

![CleanShot 2025-06-05 at 22 56 29@2x](https://github.com/user-attachments/assets/f5f0b86c-b971-41b6-bdfa-f1e32cbf9a24)


Some rendering backends may not be supported by the user’s browser. However, the ThorVG viewer still displays renderer options that won’t work in such cases.

This update adds logic to detect whether WebGL or WebGPU is available on the current system, and disables the corresponding options when they’re not supported.