### PR TITLE
ui: Add content boundary box for geometry guidance

### DIFF
--- a/style.css
+++ b/style.css
@@ -823,7 +823,7 @@ lottie-player {
     overflow: hidden;
     display: block;
     z-index: 100;
-    border: 3px solid rgba(136, 136, 136, 0.3);
+    border: 1px solid rgba(136, 136, 136, 0.3);
 }
 
 #renderer-select {

--- a/style.css
+++ b/style.css
@@ -823,6 +823,7 @@ lottie-player {
     overflow: hidden;
     display: block;
     z-index: 100;
+    border: 3px solid rgba(136, 136, 136, 0.3);
 }
 
 #renderer-select {
@@ -1005,8 +1006,4 @@ lottie-player {
     .drawer-toggle {
         display: none;
     }
-}
-
-.thorvg {
-    border: 3px solid rgba(136, 136, 136, 0.3);
 }

--- a/style.css
+++ b/style.css
@@ -1006,3 +1006,7 @@ lottie-player {
         display: none;
     }
 }
+
+.thorvg {
+    border: 3px solid rgba(136, 136, 136, 0.3);
+}


### PR DESCRIPTION
### Summary
Adds a light border around the canvas to make the content boundary visible and easier to understand.

<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/039befc9-9978-40c2-9ad0-fb9e28393489" />

### Related Issue
#102 